### PR TITLE
Fix for #19

### DIFF
--- a/Source/Chargify.NET/Product.cs
+++ b/Source/Chargify.NET/Product.cs
@@ -157,9 +157,11 @@ namespace ChargifyNET
                         _expirationIntervalUnit = obj.GetJSONContentAsIntervalUnit(key);
                         break;
                     case "return_url":
+                    case "update_return_url":
                         _returnURL = obj.GetJSONContentAsString(key);
                         break;
                     case "return_params":
+                    case "update_return_params":
                         _returnParams = obj.GetJSONContentAsString(key);
                         break;
                     case "require_credit_card":
@@ -256,9 +258,11 @@ namespace ChargifyNET
                         _expirationIntervalUnit = dataNode.GetNodeContentAsIntervalUnit();
                         break;
                     case "return_url":
+                    case "update_return_url":
                         _returnURL = dataNode.GetNodeContentAsString();
                         break;
                     case "return_params":
+                    case "update_return_params":
                         _returnParams = dataNode.GetNodeContentAsString();
                         break;
                     case "require_credit_card":


### PR DESCRIPTION
Hi,

Sorry I'm still a bit new at the Pull Request flow in Github, and I'm new to Chargify.NET too.

This PR looks for fields named "update_return_url" and "update_return_params" rather than just "return_url" and "return_params", because they seemed to have been renamed at Chargify's end.

Perhaps it would be a better idea to just rename the fields on the Chargify.NET Product to be UpdateReturnUrl and UpdateReturnParams, so that they match the new names from Chargify?