### PR TITLE
Fixed URL encode of Update Subscription URL Retrievals

### DIFF
--- a/Source/ChargifyDotNet/ChargifyConnect.cs
+++ b/Source/ChargifyDotNet/ChargifyConnect.cs
@@ -1162,10 +1162,10 @@ namespace ChargifyNET
 
             string message = UpdateShortName + "--" + subscriptionId + "--" + SharedKey;
             string token = message.GetChargifyHostedToken();
-            string prettyId = string.Format("{0}-{1}-{2}", subscriptionId, firstName.Trim().ToLower(), lastName.Trim().ToLower());
+            string prettyId = string.Format("{0}-{1}-{2}", subscriptionId, PCLWebUtility.WebUtility.UrlEncode(firstName.Trim().ToLower()), PCLWebUtility.WebUtility.UrlEncode(lastName.Trim().ToLower()));
             string methodString = string.Format("{0}/{1}/{2}", UpdateShortName, prettyId, token);
             // just in case?
-            methodString = PCLWebUtility.WebUtility.UrlEncode(methodString);
+            // methodString = PCLWebUtility.WebUtility.UrlEncode(methodString);
             string updateUrl = string.Format("{0}{1}{2}", URL, (URL.EndsWith("/") ? "" : "/"), methodString);
             return updateUrl;
         }
@@ -1182,7 +1182,7 @@ namespace ChargifyNET
             string message = UpdateShortName + "--" + subscriptionId + "--" + SharedKey;
             string token = message.GetChargifyHostedToken();
             string methodString = string.Format("{0}/{1}/{2}", UpdateShortName, subscriptionId, token);
-            methodString = PCLWebUtility.WebUtility.UrlEncode(methodString);
+            // methodString = PCLWebUtility.WebUtility.UrlEncode(methodString);
             string updateUrl = string.Format("{0}{1}{2}", URL, (URL.EndsWith("/") ? "" : "/"), methodString);
             return updateUrl;
         }


### PR DESCRIPTION
Removed URL encode of entire methodstring for GetPrettySubscriptionUpdateURL and GetSubscriptionUpdateURL and instead only urlEncoded FirstName and LastName for GetPrettySubscriptionUpdateURL. (I saw these two as the potentially problematic variables whereas the other ones I don't think need to be encoded).