### PR TITLE
Fix bug where method to retrieve subscriptions by state needs to pass…

### DIFF
--- a/Source/Chargify.NET/ChargifyConnect.cs
+++ b/Source/Chargify.NET/ChargifyConnect.cs
@@ -1344,7 +1344,7 @@ namespace ChargifyNET
 
                     // Append the kind to the query string ...
                     if (qs.Length > 0) { qs += "&"; }
-                    qs += string.Format("kinds[]={0}", state.ToString().ToLower());
+                    qs += string.Format("state[]={0}", state.ToString().ToLower());
                 }
             }
 


### PR DESCRIPTION
Fix bug where method to retrieve subscriptions by state needs to pass values using a parameter named "state" rather than one called "kinds". I think the use of "kinds" relates to retrieving transactions rather than subscriptions.