### PR TITLE
Update payment collection methods.

### DIFF
--- a/Source/ChargifyDotNet.Tests/InvoiceTests.cs
+++ b/Source/ChargifyDotNet.Tests/InvoiceTests.cs
@@ -37,7 +37,7 @@ namespace ChargifyDotNetTests
             Assert.IsNotNull(product, "No valid product was found.");
 
             // Act
-            var result = Chargify.CreateSubscription(product.Handle, customer.ChargifyID, PaymentCollectionMethod.Invoice);
+            var result = Chargify.CreateSubscription(product.Handle, customer.ChargifyID, PaymentCollectionMethod.Remittance);
 
             // Assert
             //Assert.IsInstanceOfType(result, typeof(Subscription));
@@ -54,7 +54,7 @@ namespace ChargifyDotNetTests
             Assert.IsTrue(result.Customer.SystemID == customer.SystemID);
             Assert.IsTrue(result.ProductPriceInCents == product.PriceInCents);
             Assert.IsTrue(result.ProductPrice == product.Price);
-            Assert.IsTrue(result.PaymentCollectionMethod == PaymentCollectionMethod.Invoice);
+            Assert.IsTrue(result.PaymentCollectionMethod == PaymentCollectionMethod.Remittance);
 
             // Cleanup
             Assert.IsTrue(Chargify.DeleteSubscription(result.SubscriptionID, "Automatic cancel due to test"));
@@ -71,7 +71,7 @@ namespace ChargifyDotNetTests
             var newCustomer = new CustomerAttributes(faker.Name.FirstName(), faker.Name.LastName(), faker.Internet.Email(), faker.Phone.PhoneNumber(), faker.Company.CompanyName(), referenceID);
 
             // Act
-            var newSubscription = Chargify.CreateSubscription(product.Handle, newCustomer, PaymentCollectionMethod.Invoice);
+            var newSubscription = Chargify.CreateSubscription(product.Handle, newCustomer, PaymentCollectionMethod.Remittance);
 
             // Assert
             //Assert.IsInstanceOfType(newSubscription, typeof(Subscription));
@@ -88,7 +88,7 @@ namespace ChargifyDotNetTests
             Assert.IsTrue(newSubscription.Customer.SystemID == referenceID);
             Assert.IsTrue(newSubscription.ProductPriceInCents == product.PriceInCents);
             Assert.IsTrue(newSubscription.ProductPrice == product.Price);
-            Assert.IsTrue(newSubscription.PaymentCollectionMethod == PaymentCollectionMethod.Invoice);
+            Assert.IsTrue(newSubscription.PaymentCollectionMethod == PaymentCollectionMethod.Remittance);
 
             // Cleanup
             Assert.IsTrue(Chargify.DeleteSubscription(newSubscription.SubscriptionID, "Automatic cancel due to test"));

--- a/Source/ChargifyDotNet.Tests/SubscriptionTests.cs
+++ b/Source/ChargifyDotNet.Tests/SubscriptionTests.cs
@@ -312,7 +312,7 @@ namespace ChargifyDotNetTests
             // Arrange
             var client = Chargify;
             var subscription = client.GetSubscriptionList().FirstOrDefault(s => s.Value.State == SubscriptionState.Active).Value;
-            var paymentCollectionMethod = subscription.PaymentCollectionMethod == PaymentCollectionMethod.Automatic ? PaymentCollectionMethod.Invoice : PaymentCollectionMethod.Automatic;
+            var paymentCollectionMethod = subscription.PaymentCollectionMethod == PaymentCollectionMethod.Automatic ? PaymentCollectionMethod.Remittance : PaymentCollectionMethod.Automatic;
 
             // Act
             var updatedSubscription = client.UpdatePaymentCollectionMethod(subscription.SubscriptionID, paymentCollectionMethod);

--- a/Source/ChargifyDotNet/Interfaces/ISubscription.cs
+++ b/Source/ChargifyDotNet/Interfaces/ISubscription.cs
@@ -49,8 +49,8 @@ namespace ChargifyNET
         /// <summary>
         /// Invoices are issued to users, paid and organized by staff
         /// </summary>
-        [XmlEnum("invoice")]
-        Invoice,
+        [XmlEnum("remittance")]
+        Remittance,
         /// <summary>
         /// The default state if the value could not be parsed, or wasn't sent.
         /// </summary>


### PR DESCRIPTION
The Chargify payment collection method values have changed. Specifically `invoice` is now `remittance`. The documentation on the Chargify has not been updated to reflect this but we noticed it in when querying subscriptions the API would throw an exception as the Enum would not parse.